### PR TITLE
Add `esc` shortcut to overlays

### DIFF
--- a/src/Skybrud.Umbraco.Redirects.Import/wwwroot/Views/Overlays/Export.html
+++ b/src/Skybrud.Umbraco.Redirects.Import/wwwroot/Views/Overlays/Export.html
@@ -73,7 +73,13 @@
             </umb-editor-container>
 <umb-editor-footer>
     <umb-editor-footer-content-right>
-        <umb-button action="model.close()" button-style="link" label="{{model.closeButtonLabel || 'Close'}}" type="button"></umb-button>
+        <umb-button
+            type="button"
+            button-style="link"
+            label="{{model.closeButtonLabel || 'Close'}}"
+            action="model.close()"
+            shortcut="esc">
+        </umb-button>
         <umb-button type="submit"
                     button-style="success"
                     disabled="model.submitButtonDisabled"

--- a/src/Skybrud.Umbraco.Redirects.Import/wwwroot/Views/Overlays/Import.html
+++ b/src/Skybrud.Umbraco.Redirects.Import/wwwroot/Views/Overlays/Import.html
@@ -76,7 +76,13 @@
             </umb-editor-container>
             <umb-editor-footer>
                 <umb-editor-footer-content-right>
-                    <umb-button action="model.close()" button-style="link" label="{{model.closeButtonLabel || 'Close'}}" type="button"></umb-button>
+                    <umb-button
+                        type="button"
+                        button-style="link"
+                        label="{{model.closeButtonLabel || 'Close'}}"
+                        action="model.close()"
+                        shortcut="esc">
+                    </umb-button>
                     <umb-button type="submit"
                                 button-style="success"
                                 disabled="model.submitButtonDisabled"


### PR DESCRIPTION
Allow Export and Import overlay to be closed using `esc` key.