### PR TITLE
Use button element instead on anchor in export overlay

### DIFF
--- a/src/Skybrud.Umbraco.Redirects.Import/wwwroot/Styles/Default.less
+++ b/src/Skybrud.Umbraco.Redirects.Import/wwwroot/Styles/Default.less
@@ -38,9 +38,9 @@
 ul.redirects-providers, ul.redirects-importers, ul.redirects-exporters {
 
     list-style: none;
-        margin: 0;
+    margin: 0;
 
-    a {
+    button {
         display: flex;
         padding: 10px;
         margin: 0;

--- a/src/Skybrud.Umbraco.Redirects.Import/wwwroot/Views/Overlays/Export.html
+++ b/src/Skybrud.Umbraco.Redirects.Import/wwwroot/Views/Overlays/Export.html
@@ -13,13 +13,13 @@
                                 <umb-box-content>
                                     <ul class="redirects-importers">
                                         <li ng-repeat="exporter in vm.exporters">
-                                            <a ng-click="vm.selectExporter(exporter)">
+                                            <button type="button" class="btn-reset w-100 text-left" ng-click="vm.selectExporter(exporter)">
                                                 <umb-icon icon="{{exporter.icon}}"></umb-icon>
                                                 <div>
                                                     <strong ng-bind="exporter.name"></strong><br />
                                                     <small ng-bind="exporter.description"></small>
                                                 </div>
-                                            </a>
+                                            </button>
                                         </li>
                                     </ul>
                                 </umb-box-content>
@@ -48,13 +48,13 @@
     <umb-box-content>
         <ul class="redirects-exporters">
             <li ng-repeat="exporter in vm.exporters">
-                <a ng-click="vm.selectExporter(exporter)">
+                <button type="button" class="btn-reset w-100 text-left" ng-click="vm.selectExporter(exporter)">
                     <umb-icon icon="{{exporter.icon}}"></umb-icon>
                     <div>
                         <strong ng-bind="exporter.name"></strong><br />
                         <small ng-bind="exporter.description"></small>
                     </div>
-                </a>
+                </button>
             </li>
         </ul>
     </umb-box-content>

--- a/src/Skybrud.Umbraco.Redirects.Import/wwwroot/Views/Overlays/Import.html
+++ b/src/Skybrud.Umbraco.Redirects.Import/wwwroot/Views/Overlays/Import.html
@@ -11,13 +11,13 @@
                                 <umb-box-content>
                                     <ul class="redirects-importers">
                                         <li ng-repeat="importer in vm.importers">
-                                            <a ng-click="vm.selectImporter(importer)">
+                                            <button type="button" class="btn-reset w-100 text-left" ng-click="vm.selectImporter(importer)">
                                                 <umb-icon icon="{{importer.icon}}"></umb-icon>
                                                 <div>
                                                     <strong ng-bind="importer.name"></strong><br />
                                                     <small ng-bind="importer.description"></small>
                                                 </div>
-                                            </a>
+                                            </button>
                                         </li>
                                     </ul>
                                 </umb-box-content>
@@ -41,7 +41,7 @@
                                         <div class="skybrud-borgerdk-item-content">
                                             <div class="skybrud-borgerdk-item-title">
                                                 <div class="skybrud-borgerdk-item-icon">
-                                                    <i class="icon-delete color-red"></i>
+                                                    <umb-icon icon="'icon-delete'" class="color-red"></umb-icon>
                                                 </div>
                                                 <div class="skybrud-borgerdk-item-name color-red">
                                                     Import failed
@@ -57,7 +57,7 @@
                                         <div class="skybrud-borgerdk-item-content">
                                             <div class="skybrud-borgerdk-item-title">
                                                 <div class="skybrud-borgerdk-item-icon">
-                                                    <i ng-show="item.icon" class="{{item.icon}}"></i>
+                                                    <umb-icon ng-show="item.icon" icon="{{item.icon}}"></umb-icon>
                                                 </div>
                                                 <div class="skybrud-borgerdk-item-name">
                                                     {{item.options.originalUrl}}


### PR DESCRIPTION
I noticed the import and export actions use `<a>` element, but unless linking to something, `<button>` element is better when in comes to accessibility, although anchor can have `role="buttton"`.