### PR TITLE
Issue #19 and #21 - allowed content types and ParseRootNode from domain

### DIFF
--- a/src/Skybrud.Umbraco.Redirects.Import/Importers/Csv/CsvImporter.cs
+++ b/src/Skybrud.Umbraco.Redirects.Import/Importers/Csv/CsvImporter.cs
@@ -92,7 +92,8 @@ namespace Skybrud.Umbraco.Redirects.Import.Importers.Csv {
                 return CsvImportResult.Failed(errors);
             }
 
-            if (options.File.ContentType != "text/csv" || Path.GetExtension(options.File.FileName).ToLowerInvariant() != ".csv") {
+            if (!RedirectsImportConstants.ContentTypes.AllowedCsvContentTypes.Contains(options.File.ContentType) ||
+                Path.GetExtension(options.File.FileName).ToLowerInvariant() != ".csv") {
                 errors.Add("Uploaded file doesn't look like a CSV file.");
                 return CsvImportResult.Failed(errors);
             }

--- a/src/Skybrud.Umbraco.Redirects.Import/RedirectsImportConstants.cs
+++ b/src/Skybrud.Umbraco.Redirects.Import/RedirectsImportConstants.cs
@@ -1,4 +1,6 @@
-﻿namespace Skybrud.Umbraco.Redirects.Import {
+﻿using System.Collections.Generic;
+
+namespace Skybrud.Umbraco.Redirects.Import {
 
     /// <summary>
     /// Static class with various constants used throughout this package.
@@ -9,6 +11,12 @@
         /// Static class with constants for various content types.
         /// </summary>
         public static class ContentTypes {
+
+
+            /// <summary>
+            /// Gets a list of the allowed content types for CSV files
+            /// </summary>
+            public static readonly IList<string> AllowedCsvContentTypes = new[] { "application/vnd.ms-excel", "text/csv" };
 
             /// <summary>
             /// Gets the content type for a <strong>CSV</strong> file.

--- a/src/Skybrud.Umbraco.Redirects.Import/RedirectsImportHelper.cs
+++ b/src/Skybrud.Umbraco.Redirects.Import/RedirectsImportHelper.cs
@@ -342,7 +342,7 @@ namespace Skybrud.Umbraco.Redirects.Import {
                 item.Errors.Add($"Domain doesn't have a root node ID: '{valueRootNode}'");
             } else {
                 item.AddOptions.RootNodeId = domain.RootContentId.Value;
-                if (TryGetContent(rootNodeId, out IPublishedContent? content)) {
+                if (TryGetContent(domain.RootContentId.Value, out IPublishedContent? content)) {
                     item.AddOptions.RootNodeKey = content.Key;
                     return;
                 }


### PR DESCRIPTION
Resolving the below bugs:

- #21 
- #19 

Please let me know if you have any feedback :)

I'm happy to extend the `AllowedCsvContentTypes` for additional types as per my comment on  #19  but these are the two I've tested and seem to be most common so I haven't included the others as of yet.
